### PR TITLE
requirements: Update Flask-SQLAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alembic==0.9.10
 Babel==2.9.1
 certifi==2018.4.16
 chardet==3.0.4
+charset-normalizer==2.0.12
 click==6.7
 feedgen==0.9.0
 feedparser==6.0.8
@@ -12,7 +13,7 @@ Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.14.2
 idna==2.7
 itsdangerous==0.24
-Jinja2>=2.10.1
+Jinja2==2.11.3
 lxml==4.6.5
 Mako==1.0.7
 MarkupSafe==1.1.1
@@ -21,8 +22,9 @@ python-dateutil==2.7.3
 python-editor==1.0.3
 pytz==2018.5
 requests==2.26.0
+sgmllib3k==1.0.0
 six==1.11.0
-SQLAlchemy>=1.3.0
-urllib3>=1.25.2
+SQLAlchemy==1.4.36
+urllib3==1.26.9
 Werkzeug==0.15.5
 WTForms==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ feedparser==6.0.8
 Flask==1.0.2
 Flask-Babel==0.11.2
 Flask-Migrate==2.2.1
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.14.2
 idna==2.7
 itsdangerous==0.24


### PR DESCRIPTION
SQLAlchemy 1.4 introduced changes which makes Flask-SQLAlchemy
incompatible when used with an SQlite3 database.

see https://github.com/pallets-eco/flask-sqlalchemy/issues/938

Fixes #17 